### PR TITLE
support for multiple configurations

### DIFF
--- a/examples/multiple/Gruntfile.js
+++ b/examples/multiple/Gruntfile.js
@@ -1,0 +1,21 @@
+module.exports = function(grunt) {
+    grunt.loadTasks("../../tasks");
+
+    grunt.initConfig({
+        foreman: {
+            dev: {
+                env: [ "development.env"],
+                procfile: "Procfile.dev",
+                port: 7000
+            },
+            production: {
+                env: [ "application.env" ],
+                procfile: "Procfile.dev",
+                port: 9000
+            }
+        }
+    });
+
+    grunt.registerTask("default", "foreman");   // should default to dev
+    grunt.registerTask("pro", "foreman:production");
+};

--- a/examples/multiple/Procfile.dev
+++ b/examples/multiple/Procfile.dev
@@ -1,0 +1,1 @@
+web: node dummy.js

--- a/examples/multiple/application.env
+++ b/examples/multiple/application.env
@@ -1,0 +1,1 @@
+LALA=lala

--- a/examples/multiple/development.env
+++ b/examples/multiple/development.env
@@ -1,0 +1,2 @@
+FOO=bar
+BAZ=qux

--- a/examples/multiple/dummy.js
+++ b/examples/multiple/dummy.js
@@ -1,0 +1,12 @@
+// Dummy HTTP Server
+console.log("Server Initialising");
+
+var http = require("http");
+
+var server = http.createServer(function(req, res) {
+    res.end("Thanks for HTTP " + req.method + "ing my server. Bye!");
+});
+
+server.listen(process.env.PORT, function() {
+    console.log("Server Listening at " + process.env.PORT);
+});

--- a/tasks/foreman.js
+++ b/tasks/foreman.js
@@ -1,13 +1,12 @@
 var spawn = require("child_process").spawn;
 
 module.exports = function(grunt) {
-    grunt.registerTask("foreman", function() {
+    grunt.registerMultiTask("foreman", function() {
         var done = this.async();
 
-        var target = grunt.option("target");
         var config = grunt.config.get("foreman");
 
-	    var foreman = spawn("foreman", buildArgs(target, config));
+	    var foreman = spawn("foreman", buildArgs(this.target, config));
 
 	    foreman.stdout.pipe(process.stdout);
         foreman.stderr.pipe(process.stderr);
@@ -35,7 +34,7 @@ function buildArgs(target, config) {
 //        Object.keys(options.concurrency).forEach(function(key) {
 //            var value = +options.concurrency[key];
 //            concurrency.push(key + "=" + value);
-//        });        
+//        });
 
 //        args = args.concat("--concurrency", concurrency.join(","));
 //    }
@@ -46,4 +45,3 @@ function buildArgs(target, config) {
 
     return args;
 }
-


### PR DESCRIPTION
Adding ability to create multiple configurations as suggested in README with matching examples 

### Changes: 
- Using registerMultiTask to allow multiple configurations
- buildArgs target argument now comes from `this.target` (`grunt.option("target")` was always undefined)
- Matching example added under `examples/multiple`

