### PR TITLE
add windows detection

### DIFF
--- a/tasks/foreman.js
+++ b/tasks/foreman.js
@@ -4,7 +4,11 @@ module.exports = function(grunt) {
     if(grunt.config.data["foreman"]) {
       grunt.registerMultiTask("foreman", function() {
           var done = this.async();
-          var foreman = spawn("foreman", buildArgs(this.target, grunt.config.get("foreman")));
+          
+          var command = "foreman";
+          if(process.platform === 'win32') command = "foreman.bat";
+
+          var foreman = spawn(command, buildArgs(this.target, grunt.config.get("foreman")));
 
           foreman.stdout.pipe(process.stdout);
           foreman.stderr.pipe(process.stderr);


### PR DESCRIPTION
windows nodejs didn't seem to like spawning ```foreman```.

Exec would work fine, cmd.exe could see ```foreman``` but nodejs spawn did not. 
Setting the env in spawn didnt seem to work either.

Foreman was installed through heroku and added to the path via ```%heroku%/bin```

Changing the spawn command to ```foreman.bat``` appears to fix it.

Win 7 x64 - heroku